### PR TITLE
fix: support upload file

### DIFF
--- a/codegen-gql.mjs
+++ b/codegen-gql.mjs
@@ -19,6 +19,11 @@ fs.writeFileSync(
       `import useSWR from './useSWR';
 import`,
     )
+    .replace(
+      `import { GraphQLClientRequestHeaders } from 'graphql-request/build/cjs/types';`,
+      `import { RequestConfig } from 'graphql-request/src/types';`
+    )
+    .replaceAll('GraphQLClientRequestHeaders', `RequestConfig['headers']`)
     .replace(/graphql\-request\/dist\//g, 'graphql-request/src/')
     .replace(
       /\s*id:\sstring,\s*fieldName:\s*keyof\s*Variables,\s*fieldValue:\s*Variables\[\s*typeof\sfieldName\s*\]\s*/,

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@graphql-codegen/cli": "^5.0.0",
     "@graphql-codegen/typescript": "^4.0.1",
-    "@graphql-codegen/typescript-graphql-request": "^6.0.1",
+    "@graphql-codegen/typescript-graphql-request": "^6.1.0",
     "@graphql-codegen/typescript-operations": "^4.0.1",
     "@types/node": "^20.10.1",
     "@types/react": "^18.2.35",
@@ -43,7 +43,7 @@
   "dependencies": {
     "@tenx-ui/materials": "1.5.12-beta.2",
     "graphql": "^16.8.1",
-    "graphql-request": "^6.1.0",
+    "graphql-request": "^5.2.0",
     "graphql-tag": "^2.12.6",
     "query-string": "^8.1.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^16.8.1
     version: 16.8.1
   graphql-request:
-    specifier: ^6.1.0
-    version: 6.1.0(graphql@16.8.1)
+    specifier: ^5.2.0
+    version: 5.2.0(graphql@16.8.1)
   graphql-tag:
     specifier: ^2.12.6
     version: 2.12.6(graphql@16.8.1)
@@ -29,8 +29,8 @@ devDependencies:
     specifier: ^4.0.1
     version: 4.0.1(graphql@16.8.1)
   '@graphql-codegen/typescript-graphql-request':
-    specifier: ^6.0.1
-    version: 6.0.1(graphql-request@6.1.0)(graphql-tag@2.12.6)(graphql@16.8.1)
+    specifier: ^6.1.0
+    version: 6.1.0(graphql-request@5.2.0)(graphql-tag@2.12.6)(graphql@16.8.1)
   '@graphql-codegen/typescript-operations':
     specifier: ^4.0.1
     version: 4.0.1(graphql@16.8.1)
@@ -111,7 +111,7 @@ packages:
     dependencies:
       '@ant-design/colors': 6.0.0
       '@ant-design/icons-svg': 4.3.1
-      '@babel/runtime': 7.23.4
+      '@babel/runtime': 7.23.6
       classnames: 2.3.2
       lodash: 4.17.21
       rc-util: 5.38.1(react-dom@17.0.2)(react@18.2.0)
@@ -706,7 +706,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.0
-    dev: true
 
   /@babel/template@7.22.15:
     resolution: {integrity: sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==}
@@ -1386,8 +1385,8 @@ packages:
       tslib: 2.5.3
     dev: true
 
-  /@graphql-codegen/typescript-graphql-request@6.0.1(graphql-request@6.1.0)(graphql-tag@2.12.6)(graphql@16.8.1):
-    resolution: {integrity: sha512-aScw7ICyscW7bYLh2HyjQU3geCAjvFy6sRIlzgdkeFvcKBdjCil69upkyZAyntnSno2C4ZoUv7sHOpyQ9hQmFQ==}
+  /@graphql-codegen/typescript-graphql-request@6.1.0(graphql-request@5.2.0)(graphql-tag@2.12.6)(graphql@16.8.1):
+    resolution: {integrity: sha512-hMhBazvdSQWuOrH6GnYew8zb9wDq9le0o3tPu07if/v97LVVKsVfPNcMG/cTLYZufaog9o2jScLbyo17HEqicg==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -1398,7 +1397,7 @@ packages:
       '@graphql-codegen/visitor-plugin-common': 2.13.1(graphql@16.8.1)
       auto-bind: 4.0.0
       graphql: 16.8.1
-      graphql-request: 6.1.0(graphql@16.8.1)
+      graphql-request: 5.2.0(graphql@16.8.1)
       graphql-tag: 2.12.6(graphql@16.8.1)
       tslib: 2.6.2
     transitivePeerDependencies:
@@ -2522,24 +2521,24 @@ packages:
       '@types/yargs-parser': 21.0.3
     dev: true
 
-  /@umijs/babel-preset-umi@4.1.0:
-    resolution: {integrity: sha512-NPMJY2eU7Jnr2RazaeHMC+JT3GHaX0nTEvULOp/ZkNKBaJSfpt3yuP5UXJseZJfXQaWk9LkZo2nk6UzvXnzquA==}
+  /@umijs/babel-preset-umi@4.1.1:
+    resolution: {integrity: sha512-6pYZnF03euAJGZN3VLe8PKKRNMH6Zxj4GKNooLvJ0Wz0eMufmYDcA4CpbR6h8i1JpgcQ0Sngr8bqHLb7oMqrvw==}
     dependencies:
       '@babel/runtime': 7.23.6
       '@bloomberg/record-tuple-polyfill': 0.0.4
-      '@umijs/bundler-utils': 4.1.0
-      '@umijs/utils': 4.1.0
+      '@umijs/bundler-utils': 4.1.1
+      '@umijs/utils': 4.1.1
       core-js: 3.34.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@umijs/bundler-esbuild@4.1.0:
-    resolution: {integrity: sha512-VTBhpN2HGZRmhFU6JBBklQapmq2nmCdsfwQApA+7Ei9muxFfwI+1caEpH7XYV/awimwzKngAPaS6IXpI6cnYng==}
+  /@umijs/bundler-esbuild@4.1.1:
+    resolution: {integrity: sha512-+aUT2pGTCvcn6Vla0/5E9NN8fX2QBH7XxlZP0vh1vh8iAVhYkqTu6eMSWN2hGLxlBwf5xkFJDpn3cEQ5PMUPgw==}
     hasBin: true
     dependencies:
-      '@umijs/bundler-utils': 4.1.0
-      '@umijs/utils': 4.1.0
+      '@umijs/bundler-utils': 4.1.1
+      '@umijs/utils': 4.1.1
       enhanced-resolve: 5.9.3
       postcss: 8.4.33
       postcss-flexbugs-fixes: 5.0.2(postcss@8.4.33)
@@ -2548,10 +2547,10 @@ packages:
       - supports-color
     dev: true
 
-  /@umijs/bundler-utils@4.1.0:
-    resolution: {integrity: sha512-FmZuoTDNdiBbMsxbKYv8PWix1lgn6huv6Y6jpTx/nyUpKYHg92JFluiIKb5vR2OTOJpStcvQRp3DbOMP+4L9fg==}
+  /@umijs/bundler-utils@4.1.1:
+    resolution: {integrity: sha512-k1I1tjDePgB1XqpQHZiLJ/5gS4EykY8hqqzEzD1CSbd5KFE614+q6W/gcpFZ0YLJDWY1GdjOYpRokvuI/MSRfg==}
     dependencies:
-      '@umijs/utils': 4.1.0
+      '@umijs/utils': 4.1.1
       esbuild: 0.17.19
       regenerate: 1.4.2
       regenerate-unicode-properties: 10.1.1
@@ -2560,20 +2559,20 @@ packages:
       - supports-color
     dev: true
 
-  /@umijs/bundler-webpack@4.1.0(typescript@5.0.4)(webpack@5.89.0):
-    resolution: {integrity: sha512-fahJtvzsBKuv7NNPSJ9z9wgeLng29/elVa4oINJi+7cmniXvBpuMzcNoNkAeMf6HGqqWyk8A+tcxrphEOsjxIA==}
+  /@umijs/bundler-webpack@4.1.1(typescript@5.0.4)(webpack@5.89.0):
+    resolution: {integrity: sha512-LL+ZmPmSIGOMo1+OHsBtMARqr+dTZEqDkTbQ/ZPrrrtxK27rXi/lHFEUnzKjPeHVL+xtJ4m9QR13zGWlhLT+UA==}
     hasBin: true
     dependencies:
       '@svgr/core': 6.5.1
       '@svgr/plugin-jsx': 6.5.1(@svgr/core@6.5.1)
       '@svgr/plugin-svgo': 6.5.1(@svgr/core@6.5.1)
       '@types/hapi__joi': 17.1.9
-      '@umijs/babel-preset-umi': 4.1.0
-      '@umijs/bundler-utils': 4.1.0
+      '@umijs/babel-preset-umi': 4.1.1
+      '@umijs/bundler-utils': 4.1.1
       '@umijs/case-sensitive-paths-webpack-plugin': 1.0.1
-      '@umijs/mfsu': 4.1.0
+      '@umijs/mfsu': 4.1.1
       '@umijs/react-refresh-webpack-plugin': 0.5.11(react-refresh@0.14.0)(webpack@5.89.0)
-      '@umijs/utils': 4.1.0
+      '@umijs/utils': 4.1.1
       cors: 2.8.5
       css-loader: 6.7.1(webpack@5.89.0)
       es5-imcompatible-versions: 0.1.88
@@ -2601,21 +2600,21 @@ packages:
     resolution: {integrity: sha512-kDKJ8yTarxwxGJDInG33hOpaQRZ//XpNuuznQ/1Mscypw6kappzFmrBr2dOYave++K7JHouoANF354UpbEQw0Q==}
     dev: true
 
-  /@umijs/core@4.1.0:
-    resolution: {integrity: sha512-/6o95AXepiM+2nFaIWlSOknV7n9y//3vpTJBtFg8fVK8QqEZ/+hgAsv5mkpf6y2mvEKVt/ezqh1fjjFXqUO5Sg==}
+  /@umijs/core@4.1.1:
+    resolution: {integrity: sha512-frMq29AfyLThIfrsDmNGKueT49mhL6o7P9GhnSCP3ICwTYl2aTaI3GYzf32ZCmEhFYH8cU0Bcgx5GpOIdEJrLQ==}
     dependencies:
-      '@umijs/bundler-utils': 4.1.0
-      '@umijs/utils': 4.1.0
+      '@umijs/bundler-utils': 4.1.1
+      '@umijs/utils': 4.1.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@umijs/mfsu@4.1.0:
-    resolution: {integrity: sha512-Vd4D3mWtOzsNJulzH5JFPuBMdsi2/3OwIh38mvWHhZlLtW5m+RQ0Nf2InS5Zvlw1DJvUO31TmtJniN2yCDm8ZQ==}
+  /@umijs/mfsu@4.1.1:
+    resolution: {integrity: sha512-5W4vl0vtZvD36wPUo0EMDO6p04GGPBb7MwJVQCYGdumKEwdCQ+cnzEYoJE9Q9D5PBAwnOzbf2UNrAQgtJG70tA==}
     dependencies:
-      '@umijs/bundler-esbuild': 4.1.0
-      '@umijs/bundler-utils': 4.1.0
-      '@umijs/utils': 4.1.0
+      '@umijs/bundler-esbuild': 4.1.1
+      '@umijs/bundler-utils': 4.1.1
+      '@umijs/utils': 4.1.1
       enhanced-resolve: 5.9.3
       is-equal: 1.7.0
     transitivePeerDependencies:
@@ -2650,7 +2649,7 @@ packages:
     dependencies:
       ansi-html-community: 0.0.8
       common-path-prefix: 3.0.0
-      core-js-pure: 3.35.0
+      core-js-pure: 3.35.1
       error-stack-parser: 2.1.4
       find-up: 5.0.0
       html-entities: 2.4.0
@@ -2661,8 +2660,8 @@ packages:
       webpack: 5.89.0
     dev: true
 
-  /@umijs/utils@4.1.0:
-    resolution: {integrity: sha512-rBGosE12ceUXIvBmmkJ6bDoCP8106VzMLnjlR31ZfFgos9L/GT6xW4clBURW7ddXFbZvOkvjsb4rmCbhOwUHYQ==}
+  /@umijs/utils@4.1.1:
+    resolution: {integrity: sha512-hbnbJR3RA7fu4E7q4JFZ47XMYArr6Zn5bftr8YZ+o6hzJlomr4gzoOXE+XxM7rVMK4AFZoc+QZgNTJyISd08Pg==}
     dependencies:
       chokidar: 3.5.3
       pino: 7.11.0
@@ -3060,8 +3059,7 @@ packages:
     resolution: {integrity: sha512-7HhHjtERjqlNbZtqNqy2rckN/SpOOlmDliet+lP7k+eKZEjPk3DgyeU9lIXLdeLz0uBbbVp+9Qdow9wJWgwwfg==}
 
   /asynckit@0.4.0:
-    resolution: {integrity: sha1-x57Zf380y48robyXkLzDZkdLS3k=}
-    dev: true
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   /atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
@@ -3073,15 +3071,15 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /autoprefixer@10.4.16(postcss@8.4.33):
-    resolution: {integrity: sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==}
+  /autoprefixer@10.4.17(postcss@8.4.33):
+    resolution: {integrity: sha512-/cpVNRLSfhOtcGflT13P2794gVSgmPgTR+erw5ifnMLZb0UnSlkK4tquLmkd3BhA+nLo5tX8Cu0upUsGKvKbmg==}
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      browserslist: 4.22.1
-      caniuse-lite: 1.0.30001565
+      browserslist: 4.22.2
+      caniuse-lite: 1.0.30001579
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.0.0
@@ -3280,6 +3278,17 @@ packages:
       update-browserslist-db: 1.0.13(browserslist@4.22.1)
     dev: true
 
+  /browserslist@4.22.2:
+    resolution: {integrity: sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+    dependencies:
+      caniuse-lite: 1.0.30001579
+      electron-to-chromium: 1.4.642
+      node-releases: 2.0.14
+      update-browserslist-db: 1.0.13(browserslist@4.22.2)
+    dev: true
+
   /bser@2.1.1:
     resolution: {integrity: sha1-5nh9og7OnQeZhTPP2d5vXDj0vAU=}
     dependencies:
@@ -3351,6 +3360,10 @@ packages:
 
   /caniuse-lite@1.0.30001565:
     resolution: {integrity: sha512-xrE//a3O7TP0vaJ8ikzkD2c2NgcVUvsEe2IvFTntV4Yd1Z9FVzh+gW+enX96L0psrbaFMcVcH2l90xNuGDWc8w==}
+    dev: true
+
+  /caniuse-lite@1.0.30001579:
+    resolution: {integrity: sha512-u5AUVkixruKHJjw/pj9wISlcMpgFWzSrczLZbrqBSxukQixmg0SJ5sZTpvaFvxU0HoQKd4yoyAogyrAz9pzJnA==}
     dev: true
 
   /capital-case@1.0.4:
@@ -3570,11 +3583,10 @@ packages:
     dev: true
 
   /combined-stream@1.0.8:
-    resolution: {integrity: sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=}
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
     dependencies:
       delayed-stream: 1.0.0
-    dev: true
 
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -3633,8 +3645,8 @@ packages:
     dependencies:
       toggle-selection: 1.0.6
 
-  /core-js-pure@3.35.0:
-    resolution: {integrity: sha512-f+eRYmkou59uh7BPcyJ8MC76DiGhspj1KMxVIcF24tzP8NA9HVa1uC7BTW2tgx7E1QVCzDzsgp7kArrzhlz8Ew==}
+  /core-js-pure@3.35.1:
+    resolution: {integrity: sha512-zcIdi/CL3MWbBJYo5YCeVAAx+Sy9yJE9I3/u9LkFABwbeaPhTMRWraM8mYFp9jW5Z50hOy7FVzCc8dCrpZqtIQ==}
     requiresBuild: true
     dev: true
 
@@ -3771,8 +3783,8 @@ packages:
       icss-utils: 5.1.0(postcss@8.4.33)
       postcss: 8.4.33
       postcss-modules-extract-imports: 3.0.0(postcss@8.4.33)
-      postcss-modules-local-by-default: 4.0.3(postcss@8.4.33)
-      postcss-modules-scope: 3.1.0(postcss@8.4.33)
+      postcss-modules-local-by-default: 4.0.4(postcss@8.4.33)
+      postcss-modules-scope: 3.1.1(postcss@8.4.33)
       postcss-modules-values: 4.0.0(postcss@8.4.33)
       postcss-value-parser: 4.2.0
       semver: 7.5.4
@@ -3900,9 +3912,8 @@ packages:
     dev: true
 
   /delayed-stream@1.0.0:
-    resolution: {integrity: sha1-3zrhmayt+31ECqrgsp4icrJOxhk=}
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
-    dev: true
 
   /dependency-graph@0.11.0:
     resolution: {integrity: sha1-rAzn7WilTaIhZahel6AdU/XrLic=}
@@ -4000,11 +4011,15 @@ packages:
       end-of-stream: 1.4.4
       inherits: 2.0.4
       readable-stream: 3.6.2
-      stream-shift: 1.0.2
+      stream-shift: 1.0.3
     dev: true
 
   /electron-to-chromium@1.4.596:
     resolution: {integrity: sha512-zW3zbZ40Icb2BCWjm47nxwcFGYlIgdXkAx85XDO7cyky9J4QQfq8t0W19/TLZqq3JPQXtlv8BPIGmfa9Jb4scg==}
+    dev: true
+
+  /electron-to-chromium@1.4.642:
+    resolution: {integrity: sha512-M4+u22ZJGpk4RY7tne6W+APkZhnnhmAH48FNl8iEFK2lEgob+U5rUQsIqQhvAwCXYpfd3H20pHK/ENsCvwTbsA==}
     dev: true
 
   /elliptic@6.5.4:
@@ -4248,9 +4263,8 @@ packages:
     dev: true
 
   /extract-files@9.0.0:
-    resolution: {integrity: sha1-indE8kN/gfXtMlDtnxVQ3pAv5Uo=}
+    resolution: {integrity: sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==}
     engines: {node: ^10.17.0 || ^12.0.0 || >= 13.7.0}
-    dev: true
 
   /fast-decode-uri-component@1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
@@ -4314,12 +4328,12 @@ packages:
     hasBin: true
     dependencies:
       '@microsoft/api-extractor': 7.36.3(@types/node@20.10.1)
-      '@umijs/babel-preset-umi': 4.1.0
-      '@umijs/bundler-utils': 4.1.0
-      '@umijs/bundler-webpack': 4.1.0(typescript@5.0.4)(webpack@5.89.0)
+      '@umijs/babel-preset-umi': 4.1.1
+      '@umijs/bundler-utils': 4.1.1
+      '@umijs/bundler-webpack': 4.1.1(typescript@5.0.4)(webpack@5.89.0)
       '@umijs/case-sensitive-paths-webpack-plugin': 1.0.1
-      '@umijs/core': 4.1.0
-      '@umijs/utils': 4.1.0
+      '@umijs/core': 4.1.1
+      '@umijs/utils': 4.1.1
       '@vercel/ncc': 0.33.3
       babel-plugin-dynamic-import-node: 2.3.3
       babel-plugin-module-resolver: 4.1.0
@@ -4456,13 +4470,12 @@ packages:
     dev: true
 
   /form-data@3.0.1:
-    resolution: {integrity: sha1-69U3kbeDVqma+aMA1CgsTV65dV8=}
+    resolution: {integrity: sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==}
     engines: {node: '>= 6'}
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
-    dev: true
 
   /fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
@@ -4667,6 +4680,19 @@ packages:
       - encoding
     dev: true
 
+  /graphql-request@5.2.0(graphql@16.8.1):
+    resolution: {integrity: sha512-pLhKIvnMyBERL0dtFI3medKqWOz/RhHdcgbZ+hMMIb32mEPa5MJSzS4AuXxfI4sRAu6JVVk5tvXuGfCWl9JYWQ==}
+    peerDependencies:
+      graphql: 14 - 16
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.8.1)
+      cross-fetch: 3.1.8
+      extract-files: 9.0.0
+      form-data: 3.0.1
+      graphql: 16.8.1
+    transitivePeerDependencies:
+      - encoding
+
   /graphql-request@6.1.0(graphql@16.8.1):
     resolution: {integrity: sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==}
     peerDependencies:
@@ -4677,6 +4703,7 @@ packages:
       graphql: 16.8.1
     transitivePeerDependencies:
       - encoding
+    dev: true
 
   /graphql-tag@2.12.6(graphql@16.8.1):
     resolution: {integrity: sha1-1EGlacHSU37xDKPRYztIclMptfE=}
@@ -5426,6 +5453,7 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -5435,6 +5463,7 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true
@@ -5444,6 +5473,7 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -5453,6 +5483,7 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true
@@ -5690,14 +5721,12 @@ packages:
   /mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
     dependencies:
       mime-db: 1.52.0
-    dev: true
 
   /mimic-fn@2.1.0:
     resolution: {integrity: sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=}
@@ -5805,6 +5834,10 @@ packages:
 
   /node-releases@2.0.13:
     resolution: {integrity: sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==}
+    dev: true
+
+  /node-releases@2.0.14:
+    resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
     dev: true
 
   /normalize-path@2.1.1:
@@ -6334,8 +6367,8 @@ packages:
       postcss: 8.4.33
     dev: true
 
-  /postcss-modules-local-by-default@4.0.3(postcss@8.4.33):
-    resolution: {integrity: sha512-2/u2zraspoACtrbFRnTijMiQtb4GW4BvatjaG/bCjYQo8kLTdevCUlwuBHx2sCnSyrI3x3qj4ZK1j5LQBgzmwA==}
+  /postcss-modules-local-by-default@4.0.4(postcss@8.4.33):
+    resolution: {integrity: sha512-L4QzMnOdVwRm1Qb8m4x8jsZzKAaPAgrUF1r/hjDR2Xj7R+8Zsf97jAlSQzWtKx5YNiNGN8QxmPFIc/sh+RQl+Q==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
@@ -6346,8 +6379,8 @@ packages:
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-modules-scope@3.1.0(postcss@8.4.33):
-    resolution: {integrity: sha512-SaIbK8XW+MZbd0xHPf7kdfA/3eOt7vxJ72IRecn3EzuZVLr1r0orzf0MX/pN8m+NMDoo6X/SQd8oeKqGZd8PXg==}
+  /postcss-modules-scope@3.1.1(postcss@8.4.33):
+    resolution: {integrity: sha512-uZgqzdTleelWjzJY+Fhti6F3C9iF1JR/dODLs/JDefozYcKTBCdD8BIl6nNPbTbcLnGrk56hzwZC2DaGNvYjzA==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
@@ -6430,7 +6463,7 @@ packages:
       '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.4.33)
       '@csstools/postcss-stepped-value-functions': 1.0.1(postcss@8.4.33)
       '@csstools/postcss-unset-value': 1.0.2(postcss@8.4.33)
-      autoprefixer: 10.4.16(postcss@8.4.33)
+      autoprefixer: 10.4.17(postcss@8.4.33)
       browserslist: 4.22.1
       css-blank-pseudo: 3.0.3(postcss@8.4.33)
       css-has-pseudo: 3.0.4(postcss@8.4.33)
@@ -7674,8 +7707,8 @@ packages:
       xtend: 4.0.2
     dev: true
 
-  /stream-shift@1.0.2:
-    resolution: {integrity: sha512-rV4Bovi9xx0BFzOb/X0B2GqoIjvqPCttZdu0Wgtx2Dxkj7ETyWl9gmqJ4EutWRLvtZWm8dxE+InQZX1IryZn/w==}
+  /stream-shift@1.0.3:
+    resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
     dev: true
 
   /streamsearch@1.1.0:
@@ -7863,12 +7896,12 @@ packages:
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
-      terser: 5.26.0
+      terser: 5.27.0
       webpack: 5.89.0
     dev: true
 
-  /terser@5.26.0:
-    resolution: {integrity: sha512-dytTGoE2oHgbNV9nTzgBEPaqAWvcJNl66VZ0BkJqlvp71IjO8CxdBx/ykCNb47cLnCmCvRZ6ZR0tLkqvZCdVBQ==}
+  /terser@5.27.0:
+    resolution: {integrity: sha512-bi1HRwVRskAjheeYl291n3JC4GgO/Ty4z1nVs5AAsmonJulGxpSektecnNedrwK9C7vpvVtcX3cw00VSLt7U2A==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -7932,7 +7965,7 @@ packages:
     resolution: {integrity: sha1-bkWxJj8gF/oKzH2J14sVuL932jI=}
 
   /tr46@0.0.3:
-    resolution: {integrity: sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=}
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   /traverse@0.6.6:
     resolution: {integrity: sha512-kdf4JKs8lbARxWdp7RKdNzoJBhGUcIalSYibuGyHJbmk40pOysQ0+QPvlkCOICOivDWU2IJo2rkrxyTK2AH4fw==}
@@ -8078,6 +8111,17 @@ packages:
       picocolors: 1.0.0
     dev: true
 
+  /update-browserslist-db@1.0.13(browserslist@4.22.2):
+    resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+    dependencies:
+      browserslist: 4.22.2
+      escalade: 3.1.1
+      picocolors: 1.0.0
+    dev: true
+
   /upper-case-first@2.0.2:
     resolution: {integrity: sha1-mSwyc/iCq9GdHgKJTMFHEX+EQyQ=}
     dependencies:
@@ -8200,7 +8244,7 @@ packages:
     dev: true
 
   /webidl-conversions@3.0.1:
-    resolution: {integrity: sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=}
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
   /webpack-sources@3.2.3:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
@@ -8248,7 +8292,7 @@ packages:
     dev: true
 
   /whatwg-url@5.0.0:
-    resolution: {integrity: sha1-lmRU6HZUYuN2RNNib2dCzotwll0=}
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import { GraphQLClient } from 'graphql-request';
 import type {
-  GraphQLClientResponse,
   RequestConfig,
   RequestMiddleware,
+  Response,
 } from 'graphql-request/src/types';
 import qs from 'query-string';
 import { useMemo } from 'react';
@@ -50,9 +50,9 @@ export const requestMiddleware: RequestMiddleware<any> = (request) => {
   };
 };
 
-export const responseMiddleware = (response: GraphQLClientResponse<any> | Error) => {
+export const responseMiddleware = (response: Response<any> | Error) => {
   const errors =
-    (response as GraphQLClientResponse<any>).errors || (response as any).response?.errors;
+    (response as Response<any>).errors || (response as any).response?.errors;
   if (errors) {
     errorsHandler(errors);
   }


### PR DESCRIPTION
Lower the `graphql-request` version to support file uploads.

refer to [Remove file handling](https://github.com/jasonkuhrt/graphql-request/issues/500) 、[feat: export GraphQLClientRequestHeader](https://github.com/jasonkuhrt/graphql-request/pull/558)
